### PR TITLE
Migrate to Jenkins Remoting APIs: use `FilePath` for files and `Launcher` for processes (agent-safe IO + CLT execution)

### DIFF
--- a/src/main/java/io/jenkins/plugins/finitestate/FiniteStateExecutionFramework.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/FiniteStateExecutionFramework.java
@@ -6,9 +6,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
 /**
  * Execution framework for Finite State analysis operations.
@@ -65,9 +63,9 @@ public class FiniteStateExecutionFramework {
         recorder.logCommonInfo(run, listener, recorder.getFilePathValue());
 
         // Get CLT path
-        Path cltPath;
+        FilePath cltPath;
         try {
-            cltPath = recorder.getCLTPath(recorder.getSubdomain(), parsedApiToken, listener);
+            cltPath = recorder.getCLTPath(workspace, recorder.getSubdomain(), parsedApiToken, listener);
         } catch (IOException e) {
             String errorMessage = "ERROR: Failed to download CLT: " + e.getMessage();
             listener.getLogger().println(errorMessage);
@@ -83,7 +81,7 @@ public class FiniteStateExecutionFramework {
         }
 
         // Verify file exists
-        File fileObj = recorder.getFileFromWorkspace(workspace, recorder.getFilePathValue(), listener);
+        FilePath fileObj = recorder.getFileFromWorkspace(workspace, recorder.getFilePathValue(), listener);
         if (fileObj == null || !fileObj.exists()) {
             String errorMessage =
                     "ERROR: " + recorder.getFilePathFieldName() + " not found: " + recorder.getFilePathValue();
@@ -101,7 +99,7 @@ public class FiniteStateExecutionFramework {
         // Execute the analysis
         listener.getLogger().println("Executing Finite State " + recorder.getAnalysisType() + "...");
         int exitCode = recorder.executeAnalysis(
-                cltPath, fileObj.getAbsolutePath(), recorder.getProjectName(), parsedVersion, listener);
+                cltPath, fileObj, recorder.getProjectName(), parsedVersion, workspace, launcher, listener);
 
         return handleExitCode(recorder, run, listener, exitCode, parsedVersion);
     }


### PR DESCRIPTION
### Description
- **Why**
  - Ensure agent-safe file/process handling and follow Jenkins best practices.
  - Eliminate master-only `File`/`ProcessBuilder` usage that breaks on agent nodes.
  - Consolidate IO to workspace scope and stream outputs to Jenkins logs.

- **What changed**
  - **Core**
    - `getFileFromWorkspace` now returns `FilePath`.
    - `getCLTPath` now returns `FilePath`.
    - All file IO uses `FilePath.read()`/`FilePath.write()` and `FilePath.child(...)`.
    - Existence checks use `FilePath.exists()`.
  - **Execution**
    - Replaced `ProcessBuilder` with `Launcher` and `launcher.launch()`.
    - Commands execute on the agent with `starter.pwd(workspace)`; stdout/stderr streamed to the Jenkins log.
  - **Framework/Recorders**
    - Framework validates workspace files via `FilePath`.
    - Recorders accept and pass `FilePath` and `Launcher` through the execution flow.
  - **CLT Manager**
    - Downloads CLT into `workspace.child(...)`.
    - Basic header verification via `FilePath.read()`.

- **Behavioral changes**
  - CLT runs on the agent in the workspace directory.
  - Output is streamed to the build log via `TaskListener`.
  - All paths resolved relative to the job’s workspace.

- **API changes**
  - Method signatures updated to accept `FilePath` and `Launcher` instead of `File` and `ProcessBuilder`.
  - Potentially binary-incompatible; downstream integrations must update parameter types.

- **References**
  - `FilePath.child(String)` docs: `https://javadoc.jenkins.io/hudson/FilePath.html#child(java.lang.String)`

- **Migration guide**
  - Update any callers to pass `FilePath workspace` and `Launcher launcher`.
  - Replace local file IO with `FilePath.read()`/`write()` and path ops with `workspace.child(...)`.
  - Replace process execution with `launcher.launch()` and set `pwd(workspace)`.