### PR TITLE
feat: dual-transport (Legacy Java CLT + 2026 REST API), default Legacy [HELIX-422]

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 The Finite State Analysis Jenkins Plugin provides multiple post-build actions for integrating with the Finite State platform. Each build step selects a **Platform**:
 
-- **Alloy (legacy CLT)** — the default. Downloads and runs the Finite State CLT jar on the build agent, exactly as previous plugin versions did (requires Java on the agent). Use this if your organization is still on the Alloy platform.
-- **Helix (public v0 API)** — calls the Finite State public API (v0) directly over HTTPS. No CLT download and no Java required on the agent. Use this once your organization has migrated to Helix.
+- **Legacy Platform (Java CLT)** — the default. Downloads and runs the Finite State Java CLT on the build agent, exactly as previous plugin versions did (requires Java on the agent). Use this if your organization is still on the legacy platform.
+- **2026 Platform Release (REST API)** — calls the Finite State public API (v0) directly over HTTPS. No CLT download and no Java required on the agent. Use this once your organization has been upgraded to the 2026 platform release.
 
-Jobs saved before the Platform field existed default to **Alloy**, so upgrading the plugin does not change their behavior. Select **Helix** to opt into the v0 API path.
+Jobs saved before the Platform field existed default to **Legacy Platform**, so upgrading the plugin does not change their behavior. Select **2026 Platform Release** to opt into the v0 REST API path.
 
 This plugin gives you the ability to add Post Build actions and Pipeline steps for:
 
@@ -23,7 +23,7 @@ This plugin gives you the ability to add Post Build actions and Pipeline steps f
 - **Finite State Analyze Binary**: Upload and analyze binary files (firmware images included — large files use the API's multipart upload automatically)
 - **Finite State Import SBOM**: Import CycloneDX or SPDX SBOM files (format auto-detected)
 - **Finite State Import 3rd Party Scan**: Import third-party scan results
-- Per-step **Platform** selector: Alloy (legacy CLT, default) or Helix (public v0 API — no CLT download, no Java required on the agent)
+- Per-step **Platform** selector: Legacy Platform (Java CLT, default) or 2026 Platform Release (public v0 REST API — no CLT download, no Java required on the agent)
 - Secure credential management for API tokens
 - Optionally waits for the scan to complete and sets the build result accordingly
 - Logs the resolved project/version/scan IDs and a direct link to the results in the Finite State UI
@@ -101,9 +101,9 @@ The plugin will:
 
 ### How it talks to Finite State
 
-**Helix platform:** all calls go to your instance's public API at `https://<subdomain>/api/public/v0`, authenticated with the `X-Authorization` header using the API token from the selected credential. The flow per run is: resolve project → resolve/create version → upload + trigger the scan → poll status (optional). No CLT jar is downloaded and nothing is executed as a subprocess; the upload runs on the build agent so artifact bytes never transit the Jenkins controller.
+**2026 platform release:** all calls go to your instance's public API at `https://<subdomain>/api/public/v0`, authenticated with the `X-Authorization` header using the API token from the selected credential. The flow per run is: resolve project → resolve/create version → upload + trigger the scan → poll status (optional). No CLT is downloaded and nothing is executed as a subprocess; the upload runs on the build agent so artifact bytes never transit the Jenkins controller.
 
-**Alloy platform (default):** the plugin downloads the CLT jar from `https://<subdomain>/api/config/clt` and runs it on the build agent (`java -jar …`), passing credentials via the `FINITE_STATE_AUTH_TOKEN`/`FINITE_STATE_DOMAIN` environment variables — the same behavior as plugin versions ≤ `1.092`.
+**Legacy platform (default):** the plugin downloads the Java CLT from `https://<subdomain>/api/config/clt` and runs it on the build agent (`java -jar …`), passing credentials via the `FINITE_STATE_AUTH_TOKEN`/`FINITE_STATE_DOMAIN` environment variables — the same behavior as plugin versions ≤ `1.092`.
 
 Upload mechanics differ by type:
 - **Binary** uploads directly to storage (single PUT, or multipart for large firmware), then starts the scan.
@@ -203,7 +203,7 @@ pipeline {
 
 Notes:
 
-- `platform` selects the transport and defaults to `'alloy'` (legacy CLT). Set `platform: 'helix'` to use the public v0 API. It applies to all three steps, e.g. `finiteStateAnalyzeBinary(platform: 'helix', subdomain: '…', apiTokenCredentialsId: '…', …)`.
+- `platform` selects the transport and defaults to `'legacy'` (Java CLT). Set `platform: '2026'` to use the public v0 REST API. It applies to all three steps, e.g. `finiteStateAnalyzeBinary(platform: '2026', subdomain: '…', apiTokenCredentialsId: '…', …)`.
 
 - Use `apiTokenCredentialsId` (the ID of a Secret Text credential containing your Finite State API token).
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To use this plugin, follow the following steps:
    - `Finite State - Import 3rd Party Scan`
 4. **Generate an API Token**: You need to generate an API token from your Finite State instance. Navigate to your Finite State domain (e.g., if your domain is `fs-yolo.finitestate.io`, go to https://fs-yolo.finitestate.io/settings/api-tokens) and generate a new API token. This token will be used to authenticate with the Finite State platform.
 5. Complete the fields following the below reference. For sensitive fields like `API Token`, we use the credentials plugin, so be sure to create the text credential for this field and select the correct one on the dropdown.
+6. In the **Platform** dropdown, choose **Legacy Platform (Java CLT)** (the default) if your organization is still on the legacy platform, or **2026 Platform Release (REST API)** once your organization has been upgraded to the 2026 platform release. Leaving it at the default keeps existing jobs working unchanged after a plugin upgrade.
 
 ## Post-Build Actions
 
@@ -49,6 +50,7 @@ Uploads binary files to Finite State for comprehensive analysis.
 
 | parameter | description | required | type | default |
 |-----------|-------------|----------|------|---------|
+| Platform | Which Finite State platform to target: **Legacy Platform (Java CLT)** (default) or **2026 Platform Release (REST API)**. In Pipeline set `platform: 'legacy'` or `platform: '2026'`. | `false` | `dropdown` | `Legacy Platform (Java CLT)` |
 | Subdomain | Your Finite State instance subdomain (e.g., "fs-yolo.dev.fstate.ninja") | `true` | `string` | |
 | API Token Credentials | A Secret Text credentials ID containing your Finite State API token | `true` | `credential` | |
 | Binary File Path | Path to the binary file to upload for analysis | `true` | `string` | |
@@ -64,6 +66,7 @@ Imports SBOM (Software Bill of Materials) files to Finite State for analysis.
 
 | parameter | description | required | type | default |
 |-----------|-------------|----------|------|---------|
+| Platform | Which Finite State platform to target: **Legacy Platform (Java CLT)** (default) or **2026 Platform Release (REST API)**. In Pipeline set `platform: 'legacy'` or `platform: '2026'`. | `false` | `dropdown` | `Legacy Platform (Java CLT)` |
 | Subdomain | Your Finite State instance subdomain | `true` | `string` | |
 | API Token Credentials | A Secret Text credentials ID containing your Finite State API token | `true` | `credential` | |
 | SBOM File Path | Path to the SBOM file to import (CycloneDX or SPDX; format auto-detected) | `true` | `string` | |
@@ -78,6 +81,7 @@ Imports third-party scan results to Finite State for analysis.
 
 | parameter | description | required | type | default |
 |-----------|-------------|----------|------|---------|
+| Platform | Which Finite State platform to target: **Legacy Platform (Java CLT)** (default) or **2026 Platform Release (REST API)**. In Pipeline set `platform: 'legacy'` or `platform: '2026'`. | `false` | `dropdown` | `Legacy Platform (Java CLT)` |
 | Subdomain | Your Finite State instance subdomain | `true` | `string` | |
 | API Token Credentials | A Secret Text credentials ID containing your Finite State API token | `true` | `credential` | |
 | Scan File Path | Path to the scan results file | `true` | `string` | |
@@ -130,6 +134,7 @@ pipeline {
     stage('Finite State Binary Analysis') {
       steps {
         finiteStateAnalyzeBinary(
+          platform: 'legacy', // 'legacy' = Legacy Platform (Java CLT, default); '2026' = 2026 Platform Release (REST API)
           subdomain: 'fs-your-subdomain.finitestate.io',
           apiTokenCredentialsId: 'your-jenkins-string-credentials-id',
           binaryFilePath: 'build/firmware.bin',
@@ -159,6 +164,7 @@ pipeline {
     stage('Finite State Import SBOM') {
       steps {
         finiteStateImportSbom(
+          platform: 'legacy', // 'legacy' = Legacy Platform (Java CLT, default); '2026' = 2026 Platform Release (REST API)
           subdomain: 'fs-your-subdomain.finitestate.io',
           apiTokenCredentialsId: 'your-jenkins-string-credentials-id',
           sbomFilePath: 'sbom/cyclonedx.json',
@@ -184,6 +190,7 @@ pipeline {
     stage('Finite State Import 3rd Party Scan') {
       steps {
         finiteStateImportThirdParty(
+          platform: 'legacy', // 'legacy' = Legacy Platform (Java CLT, default); '2026' = 2026 Platform Release (REST API)
           subdomain: 'fs-your-subdomain.finitestate.io',
           apiTokenCredentialsId: 'your-jenkins-string-credentials-id',
           scanFilePath: 'reports/sonarqube.json',

--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@
 
 ## Introduction
 
-The Finite State Analysis Jenkins Plugin provides multiple post-build actions for integrating with the Finite State platform by calling the Finite State public API (v0) directly over HTTPS. (Earlier versions shelled out to the Finite State CLT jar, which is now deprecated; the plugin no longer downloads or runs it, and Java is no longer required on the build agent.)
+The Finite State Analysis Jenkins Plugin provides multiple post-build actions for integrating with the Finite State platform. Each build step selects a **Platform**:
+
+- **Alloy (legacy CLT)** — the default. Downloads and runs the Finite State CLT jar on the build agent, exactly as previous plugin versions did (requires Java on the agent). Use this if your organization is still on the Alloy platform.
+- **Helix (public v0 API)** — calls the Finite State public API (v0) directly over HTTPS. No CLT download and no Java required on the agent. Use this once your organization has migrated to Helix.
+
+Jobs saved before the Platform field existed default to **Alloy**, so upgrading the plugin does not change their behavior. Select **Helix** to opt into the v0 API path.
 
 This plugin gives you the ability to add Post Build actions and Pipeline steps for:
 
@@ -18,7 +23,7 @@ This plugin gives you the ability to add Post Build actions and Pipeline steps f
 - **Finite State Analyze Binary**: Upload and analyze binary files (firmware images included — large files use the API's multipart upload automatically)
 - **Finite State Import SBOM**: Import CycloneDX or SPDX SBOM files (format auto-detected)
 - **Finite State Import 3rd Party Scan**: Import third-party scan results
-- Talks to the Finite State public API directly — no CLT download, no Java required on the agent
+- Per-step **Platform** selector: Alloy (legacy CLT, default) or Helix (public v0 API — no CLT download, no Java required on the agent)
 - Secure credential management for API tokens
 - Optionally waits for the scan to complete and sets the build result accordingly
 - Logs the resolved project/version/scan IDs and a direct link to the results in the Finite State UI
@@ -96,7 +101,9 @@ The plugin will:
 
 ### How it talks to Finite State
 
-All calls go to your instance's public API at `https://<subdomain>/api/public/v0`, authenticated with the `X-Authorization` header using the API token from the selected credential. The flow per run is: resolve project → resolve/create version → upload + trigger the scan → poll status (optional). No CLT jar is downloaded and nothing is executed as a subprocess; the upload runs on the build agent so artifact bytes never transit the Jenkins controller.
+**Helix platform:** all calls go to your instance's public API at `https://<subdomain>/api/public/v0`, authenticated with the `X-Authorization` header using the API token from the selected credential. The flow per run is: resolve project → resolve/create version → upload + trigger the scan → poll status (optional). No CLT jar is downloaded and nothing is executed as a subprocess; the upload runs on the build agent so artifact bytes never transit the Jenkins controller.
+
+**Alloy platform (default):** the plugin downloads the CLT jar from `https://<subdomain>/api/config/clt` and runs it on the build agent (`java -jar …`), passing credentials via the `FINITE_STATE_AUTH_TOKEN`/`FINITE_STATE_DOMAIN` environment variables — the same behavior as plugin versions ≤ `1.092`.
 
 Upload mechanics differ by type:
 - **Binary** uploads directly to storage (single PUT, or multipart for large firmware), then starts the scan.
@@ -195,6 +202,8 @@ pipeline {
 ```
 
 Notes:
+
+- `platform` selects the transport and defaults to `'alloy'` (legacy CLT). Set `platform: 'helix'` to use the public v0 API. It applies to all three steps, e.g. `finiteStateAnalyzeBinary(platform: 'helix', subdomain: '…', apiTokenCredentialsId: '…', …)`.
 
 - Use `apiTokenCredentialsId` (the ID of a Secret Text credential containing your Finite State API token).
 

--- a/src/main/java/io/jenkins/plugins/finitestate/BaseFiniteStateDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/BaseFiniteStateDescriptor.java
@@ -49,15 +49,15 @@ public abstract class BaseFiniteStateDescriptor extends BuildStepDescriptor<Publ
     }
 
     /**
-     * Populate the platform/transport selector. Alloy (legacy CLT) is listed first and is the
-     * default for jobs that never set the field, keeping existing Alloy pipelines working after an
+     * Populate the platform/transport selector. The legacy platform (Java CLT) is listed first and
+     * is the default for jobs that never set the field, keeping existing pipelines working after an
      * upgrade. See {@link BaseFiniteStateRecorder} and HELIX-422.
      */
     @RequirePOST
     public ListBoxModel doFillPlatformItems() {
         ListBoxModel items = new ListBoxModel();
-        items.add("Alloy (legacy CLT)", BaseFiniteStateRecorder.PLATFORM_ALLOY);
-        items.add("Helix (public v0 API)", BaseFiniteStateRecorder.PLATFORM_HELIX);
+        items.add("Legacy Platform (Java CLT)", BaseFiniteStateRecorder.PLATFORM_LEGACY);
+        items.add("2026 Platform Release (REST API)", BaseFiniteStateRecorder.PLATFORM_2026);
         return items;
     }
 

--- a/src/main/java/io/jenkins/plugins/finitestate/BaseFiniteStateDescriptor.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/BaseFiniteStateDescriptor.java
@@ -49,6 +49,19 @@ public abstract class BaseFiniteStateDescriptor extends BuildStepDescriptor<Publ
     }
 
     /**
+     * Populate the platform/transport selector. Alloy (legacy CLT) is listed first and is the
+     * default for jobs that never set the field, keeping existing Alloy pipelines working after an
+     * upgrade. See {@link BaseFiniteStateRecorder} and HELIX-422.
+     */
+    @RequirePOST
+    public ListBoxModel doFillPlatformItems() {
+        ListBoxModel items = new ListBoxModel();
+        items.add("Alloy (legacy CLT)", BaseFiniteStateRecorder.PLATFORM_ALLOY);
+        items.add("Helix (public v0 API)", BaseFiniteStateRecorder.PLATFORM_HELIX);
+        return items;
+    }
+
+    /**
      * Common validation helper for required values
      */
     protected FormValidation checkRequiredValue(String value) {

--- a/src/main/java/io/jenkins/plugins/finitestate/BaseFiniteStateRecorder.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/BaseFiniteStateRecorder.java
@@ -17,14 +17,30 @@ import org.kohsuke.stapler.DataBoundSetter;
  * Abstract base class for all Finite State recorders.
  * Contains common functionality shared across different analysis types.
  *
- * <p>As of the v0 API migration the plugin no longer downloads or executes the CLT jar; each
- * recorder describes its work via {@link #configureRequest(FiniteStateScanRequest)} and the shared
- * {@link FiniteStateExecutionFramework} drives the REST flow.
+ * <p>The plugin supports two transports, selected per build step via {@link #getPlatform()}:
+ *
+ * <ul>
+ *   <li><b>{@value #PLATFORM_ALLOY}</b> (default) — the legacy Alloy path: download and exec the CLT
+ *       jar. Kept so existing Alloy jobs keep working unchanged after upgrading the plugin.
+ *   <li><b>{@value #PLATFORM_HELIX}</b> — the Helix path: direct calls to the public v0 REST API,
+ *       described via {@link #configureRequest(FiniteStateScanRequest)}.
+ * </ul>
+ *
+ * <p>{@link FiniteStateExecutionFramework} inspects the selected platform and drives the matching
+ * flow. The default is Alloy so that a job saved before this field existed (no {@code platform} in
+ * its persisted XML) deserializes to the legacy behavior — an upgrade never silently retargets an
+ * Alloy customer at the Helix API. See HELIX-422.
  */
 public abstract class BaseFiniteStateRecorder extends Recorder implements SimpleBuildStep {
 
     /** Default poll timeout (minutes) when waiting for scan completion (FR-7). */
     public static final int DEFAULT_POLL_TIMEOUT_MINUTES = 30;
+
+    /** Legacy Alloy transport (CLT jar download-and-exec). Default for backward compatibility. */
+    public static final String PLATFORM_ALLOY = "alloy";
+
+    /** Helix transport (direct public v0 REST API). */
+    public static final String PLATFORM_HELIX = "helix";
 
     protected String subdomain;
     // Explicit name indicating this is a Jenkins Credentials ID (Secret Text) holding the API token.
@@ -35,6 +51,8 @@ public abstract class BaseFiniteStateRecorder extends Recorder implements Simple
     protected Boolean preRelease;
     protected Boolean waitForCompletion;
     protected Integer pollTimeoutMinutes;
+    // Which backend/transport to use. Null (absent from persisted config) => legacy Alloy/CLT path.
+    protected String platform;
 
     protected BaseFiniteStateRecorder() {
         // Default constructor for inheritance
@@ -73,6 +91,20 @@ public abstract class BaseFiniteStateRecorder extends Recorder implements Simple
 
     public int getPollTimeoutMinutes() {
         return pollTimeoutMinutes != null && pollTimeoutMinutes > 0 ? pollTimeoutMinutes : DEFAULT_POLL_TIMEOUT_MINUTES;
+    }
+
+    /**
+     * Selected transport. Defaults to {@link #PLATFORM_ALLOY} when unset (including jobs whose
+     * persisted config predates this field), so upgrading the plugin never changes an existing
+     * Alloy job's behavior.
+     */
+    public String getPlatform() {
+        return platform != null && !platform.isBlank() ? platform : PLATFORM_ALLOY;
+    }
+
+    /** True when this step targets the Helix public v0 API instead of the legacy CLT. */
+    public boolean isHelix() {
+        return PLATFORM_HELIX.equalsIgnoreCase(getPlatform());
     }
 
     // Common setters
@@ -117,6 +149,11 @@ public abstract class BaseFiniteStateRecorder extends Recorder implements Simple
         this.pollTimeoutMinutes = pollTimeoutMinutes;
     }
 
+    @DataBoundSetter
+    public void setPlatform(String platform) {
+        this.platform = platform;
+    }
+
     /**
      * Get file from workspace - common utility method (pipeline and freestyle)
      */
@@ -143,6 +180,25 @@ public abstract class BaseFiniteStateRecorder extends Recorder implements Simple
             return stringCredentials.getSecret().getPlainText();
         }
         return null;
+    }
+
+    /**
+     * Get CLT path using the shared CLTManager (legacy Alloy transport only).
+     */
+    protected FilePath getCLTPath(FilePath workspace, String subdomain, String apiToken, TaskListener listener)
+            throws IOException, InterruptedException {
+        String cltUrl = "https://" + subdomain + "/api/config/clt";
+        return CLTManager.getOrDownloadCLT(cltUrl, apiToken, subdomain, workspace, listener);
+    }
+
+    /**
+     * Build the environment variables required by the CLT for authentication and domain routing
+     * (legacy Alloy transport only).
+     */
+    protected String[] buildCLTEnvironment(String apiToken) {
+        return new String[] {
+            "FINITE_STATE_AUTH_TOKEN=" + apiToken, "FINITE_STATE_DOMAIN=" + subdomain,
+        };
     }
 
     /**
@@ -216,10 +272,28 @@ public abstract class BaseFiniteStateRecorder extends Recorder implements Simple
     }
 
     /**
-     * Populate the type-specific portion of the scan request (kind + per-analysis fields). The
-     * framework fills the common fields (subdomain, token, project, version, polling, etc.).
+     * Populate the type-specific portion of the scan request (kind + per-analysis fields), used by
+     * the Helix v0 transport. The framework fills the common fields (subdomain, token, project,
+     * version, polling, etc.).
      */
     protected abstract void configureRequest(FiniteStateScanRequest request);
+
+    /**
+     * Execute the analysis via the legacy Alloy CLT transport. Invoked by
+     * {@link FiniteStateExecutionFramework} only when {@link #isHelix()} is {@code false}.
+     *
+     * @return CLT process exit code (0 = success, 1 = completed with findings, other = error)
+     */
+    protected abstract int executeAnalysis(
+            FilePath cltPath,
+            FilePath filePath,
+            String projectName,
+            String projectVersion,
+            String apiToken,
+            FilePath workspace,
+            Launcher launcher,
+            TaskListener listener)
+            throws IOException, InterruptedException;
 
     /**
      * Get the analysis type name for logging and results

--- a/src/main/java/io/jenkins/plugins/finitestate/BaseFiniteStateRecorder.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/BaseFiniteStateRecorder.java
@@ -20,27 +20,27 @@ import org.kohsuke.stapler.DataBoundSetter;
  * <p>The plugin supports two transports, selected per build step via {@link #getPlatform()}:
  *
  * <ul>
- *   <li><b>{@value #PLATFORM_ALLOY}</b> (default) — the legacy Alloy path: download and exec the CLT
- *       jar. Kept so existing Alloy jobs keep working unchanged after upgrading the plugin.
- *   <li><b>{@value #PLATFORM_HELIX}</b> — the Helix path: direct calls to the public v0 REST API,
- *       described via {@link #configureRequest(FiniteStateScanRequest)}.
+ *   <li><b>{@value #PLATFORM_LEGACY}</b> (default) — the legacy platform: download and exec the Java
+ *       CLT jar. Kept so existing jobs keep working unchanged after upgrading the plugin.
+ *   <li><b>{@value #PLATFORM_2026}</b> — the 2026 platform release: direct calls to the public v0
+ *       REST API, described via {@link #configureRequest(FiniteStateScanRequest)}.
  * </ul>
  *
  * <p>{@link FiniteStateExecutionFramework} inspects the selected platform and drives the matching
- * flow. The default is Alloy so that a job saved before this field existed (no {@code platform} in
- * its persisted XML) deserializes to the legacy behavior — an upgrade never silently retargets an
- * Alloy customer at the Helix API. See HELIX-422.
+ * flow. The default is the legacy platform so that a job saved before this field existed (no
+ * {@code platform} in its persisted XML) deserializes to the legacy behavior — an upgrade never
+ * silently retargets a job at the 2026 REST API. See HELIX-422.
  */
 public abstract class BaseFiniteStateRecorder extends Recorder implements SimpleBuildStep {
 
     /** Default poll timeout (minutes) when waiting for scan completion (FR-7). */
     public static final int DEFAULT_POLL_TIMEOUT_MINUTES = 30;
 
-    /** Legacy Alloy transport (CLT jar download-and-exec). Default for backward compatibility. */
-    public static final String PLATFORM_ALLOY = "alloy";
+    /** Legacy platform transport (Java CLT jar download-and-exec). Default for backward compatibility. */
+    public static final String PLATFORM_LEGACY = "legacy";
 
-    /** Helix transport (direct public v0 REST API). */
-    public static final String PLATFORM_HELIX = "helix";
+    /** 2026 platform release transport (direct public v0 REST API). */
+    public static final String PLATFORM_2026 = "2026";
 
     protected String subdomain;
     // Explicit name indicating this is a Jenkins Credentials ID (Secret Text) holding the API token.
@@ -51,7 +51,7 @@ public abstract class BaseFiniteStateRecorder extends Recorder implements Simple
     protected Boolean preRelease;
     protected Boolean waitForCompletion;
     protected Integer pollTimeoutMinutes;
-    // Which backend/transport to use. Null (absent from persisted config) => legacy Alloy/CLT path.
+    // Which platform/transport to use. Null (absent from persisted config) => legacy CLT path.
     protected String platform;
 
     protected BaseFiniteStateRecorder() {
@@ -94,17 +94,17 @@ public abstract class BaseFiniteStateRecorder extends Recorder implements Simple
     }
 
     /**
-     * Selected transport. Defaults to {@link #PLATFORM_ALLOY} when unset (including jobs whose
+     * Selected transport. Defaults to {@link #PLATFORM_LEGACY} when unset (including jobs whose
      * persisted config predates this field), so upgrading the plugin never changes an existing
-     * Alloy job's behavior.
+     * job's behavior.
      */
     public String getPlatform() {
-        return platform != null && !platform.isBlank() ? platform : PLATFORM_ALLOY;
+        return platform != null && !platform.isBlank() ? platform : PLATFORM_LEGACY;
     }
 
-    /** True when this step targets the Helix public v0 API instead of the legacy CLT. */
-    public boolean isHelix() {
-        return PLATFORM_HELIX.equalsIgnoreCase(getPlatform());
+    /** True when this step targets the 2026 platform's public v0 REST API instead of the legacy CLT. */
+    public boolean isRestApi() {
+        return PLATFORM_2026.equalsIgnoreCase(getPlatform());
     }
 
     // Common setters
@@ -183,7 +183,7 @@ public abstract class BaseFiniteStateRecorder extends Recorder implements Simple
     }
 
     /**
-     * Get CLT path using the shared CLTManager (legacy Alloy transport only).
+     * Get CLT path using the shared CLTManager (legacy platform transport only).
      */
     protected FilePath getCLTPath(FilePath workspace, String subdomain, String apiToken, TaskListener listener)
             throws IOException, InterruptedException {
@@ -193,7 +193,7 @@ public abstract class BaseFiniteStateRecorder extends Recorder implements Simple
 
     /**
      * Build the environment variables required by the CLT for authentication and domain routing
-     * (legacy Alloy transport only).
+     * (legacy platform transport only).
      */
     protected String[] buildCLTEnvironment(String apiToken) {
         return new String[] {
@@ -273,14 +273,14 @@ public abstract class BaseFiniteStateRecorder extends Recorder implements Simple
 
     /**
      * Populate the type-specific portion of the scan request (kind + per-analysis fields), used by
-     * the Helix v0 transport. The framework fills the common fields (subdomain, token, project,
+     * the 2026 platform's v0 REST transport. The framework fills the common fields (subdomain, token, project,
      * version, polling, etc.).
      */
     protected abstract void configureRequest(FiniteStateScanRequest request);
 
     /**
-     * Execute the analysis via the legacy Alloy CLT transport. Invoked by
-     * {@link FiniteStateExecutionFramework} only when {@link #isHelix()} is {@code false}.
+     * Execute the analysis via the legacy platform's CLT transport. Invoked by
+     * {@link FiniteStateExecutionFramework} only when {@link #isRestApi()} is {@code false}.
      *
      * @return CLT process exit code (0 = success, 1 = completed with findings, other = error)
      */

--- a/src/main/java/io/jenkins/plugins/finitestate/CLTManager.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/CLTManager.java
@@ -1,0 +1,177 @@
+package io.jenkins.plugins.finitestate;
+
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Utility class for managing the Finite State CLT (Command Line Tool) download and caching.
+ * This class provides centralized logic for downloading, caching, and validating the CLT JAR file.
+ */
+public class CLTManager {
+
+    private static final String CLT_FILENAME_PREFIX = "finitestate-clt";
+    private static final String CLT_FILENAME_SUFFIX = ".jar";
+    private static final String USER_AGENT = "FiniteState-Jenkins-Plugin/1.0";
+
+    /**
+     * Private constructor to prevent instantiation of utility class.
+     */
+    private CLTManager() {
+        // Utility class - no instantiation allowed
+    }
+
+    /**
+     * Get the CLT filename for a specific subdomain
+     *
+     * @param subdomain The subdomain to generate filename for
+     * @return The subdomain-specific CLT filename
+     */
+    private static String getCLTFilename(String subdomain) {
+        return CLT_FILENAME_PREFIX + "-" + subdomain + CLT_FILENAME_SUFFIX;
+    }
+
+    /**
+     * Get or download the CLT jar file with proper caching and validation.
+     *
+     * @param cltUrl The URL to download the CLT from
+     * @param apiToken The API token for authentication
+     * @param subdomain The subdomain for filename generation
+     * @param listener The build listener for logging
+     * @return The path to the CLT JAR file
+     * @throws IOException if download fails or file is invalid
+     */
+    public static FilePath getOrDownloadCLT(
+            String cltUrl, String apiToken, String subdomain, FilePath workspace, TaskListener listener)
+            throws IOException, InterruptedException {
+        String filename = getCLTFilename(subdomain);
+        FilePath cltPath = workspace.child(filename);
+
+        // Check if CLT already exists on the node
+        if (cltPath.exists() && cltPath.length() > 0) {
+            listener.getLogger().println("CLT already exists at: " + cltPath.getRemote());
+            return cltPath;
+        }
+
+        // Download the CLT if it doesn't exist
+        listener.getLogger().println("CLT not found, downloading from: " + cltUrl);
+        return downloadCLT(cltUrl, apiToken, subdomain, cltPath, listener);
+    }
+
+    /**
+     * Test if the JAR file is valid and executable
+     */
+    private static boolean testJarFile(FilePath jarPath, TaskListener listener)
+            throws IOException, InterruptedException {
+        try (java.io.InputStream is = jarPath.read()) {
+            byte[] header = new byte[4];
+            int read = is.read(header);
+            boolean looksLikeZip = read == 4 && header[0] == 0x50 && header[1] == 0x4B;
+            if (looksLikeZip) {
+                listener.getLogger().println("JAR file header verified successfully");
+            } else {
+                listener.getLogger().println("WARNING: File does not appear to be a valid JAR file");
+            }
+            return looksLikeZip;
+        }
+    }
+
+    /**
+     * Download the CLT jar file
+     */
+    private static FilePath downloadCLT(
+            String url, String apiToken, String subdomain, FilePath cltPath, TaskListener listener)
+            throws IOException, InterruptedException {
+        listener.getLogger().println("Downloading CLT from: " + url);
+
+        // Create URL connection with authentication
+        java.net.URLConnection connection = new URL(url).openConnection();
+        connection.setRequestProperty("X-Authorization", apiToken);
+        connection.setRequestProperty("User-Agent", USER_AGENT);
+
+        // Check response code
+        if (connection instanceof java.net.HttpURLConnection) {
+            java.net.HttpURLConnection httpConnection = (java.net.HttpURLConnection) connection;
+            int responseCode = httpConnection.getResponseCode();
+            listener.getLogger().println("HTTP Response Code: " + responseCode);
+
+            if (responseCode != 200) {
+                String errorMessage = "Failed to download CLT. HTTP Response: " + responseCode;
+
+                // Add specific error messages for common HTTP status codes
+                if (responseCode == 401) {
+                    errorMessage =
+                            "Authentication failed (HTTP 401). Please check your API token and ensure it is valid for the specified subdomain.";
+                } else if (responseCode == 403) {
+                    errorMessage = "Access denied (HTTP 403). Please check your API token permissions.";
+                } else if (responseCode == 404) {
+                    errorMessage = "CLT not found (HTTP 404). Please check the subdomain configuration.";
+                } else if (responseCode >= 500) {
+                    errorMessage =
+                            "Server error (HTTP " + responseCode + "). Please try again later or contact support.";
+                }
+
+                // Try to read error response if available
+                try {
+                    java.io.InputStream errorStream = httpConnection.getErrorStream();
+                    if (errorStream != null) {
+                        try (java.io.BufferedReader reader = new java.io.BufferedReader(
+                                new java.io.InputStreamReader(errorStream, StandardCharsets.UTF_8))) {
+                            String line;
+                            StringBuilder errorResponse = new StringBuilder();
+                            while ((line = reader.readLine()) != null) {
+                                errorResponse.append(line).append("\n");
+                            }
+                            if (errorResponse.length() > 0) {
+                                errorMessage += "\nError Response: " + errorResponse.toString();
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    // If we can't read the error stream, just log it and continue
+                    listener.getLogger().println("Warning: Could not read error response details: " + e.getMessage());
+                }
+
+                throw new IOException(errorMessage);
+            }
+        }
+
+        // Download the file
+        long totalBytes = 0;
+        try (java.io.InputStream in = connection.getInputStream();
+                java.io.OutputStream out = cltPath.write()) {
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = in.read(buffer)) != -1) {
+                out.write(buffer, 0, bytesRead);
+                totalBytes += bytesRead;
+            }
+        }
+
+        // Verify the downloaded file
+        if (!cltPath.exists()) {
+            throw new IOException("Downloaded file does not exist");
+        }
+
+        if (cltPath.length() == 0) {
+            throw new IOException("Downloaded file is empty");
+        }
+
+        listener.getLogger().println("Downloaded " + totalBytes + " bytes to: " + cltPath.getRemote());
+        listener.getLogger().println("File size: " + cltPath.length() + " bytes");
+
+        // Verify it's a valid JAR file by checking the magic number
+        testJarFile(cltPath, listener);
+
+        try {
+            cltPath.chmod(0755);
+        } catch (Exception ignore) {
+            // best effort; may fail on non-POSIX filesystems
+        }
+        listener.getLogger().println("CLT downloaded successfully to: " + cltPath.getRemote());
+
+        return cltPath;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/finitestate/FiniteStateAnalyzeBinaryRecorder.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/FiniteStateAnalyzeBinaryRecorder.java
@@ -132,7 +132,7 @@ public class FiniteStateAnalyzeBinaryRecorder extends BaseFiniteStateRecorder {
     }
 
     /**
-     * Build the CLT scan-types string from the checkboxes (legacy Alloy transport).
+     * Build the CLT scan-types string from the checkboxes (legacy platform transport).
      */
     private String buildScanTypesString() {
         List<String> selectedTypes = new ArrayList<>();
@@ -159,7 +159,7 @@ public class FiniteStateAnalyzeBinaryRecorder extends BaseFiniteStateRecorder {
     }
 
     /**
-     * Execute the CLT command for binary analysis (legacy Alloy transport).
+     * Execute the CLT command for binary analysis (legacy platform transport).
      */
     private int executeCLT(
             FilePath cltPath,

--- a/src/main/java/io/jenkins/plugins/finitestate/FiniteStateAnalyzeBinaryRecorder.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/FiniteStateAnalyzeBinaryRecorder.java
@@ -1,8 +1,13 @@
 package io.jenkins.plugins.finitestate;
 
 import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import javax.servlet.ServletException;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -89,6 +94,29 @@ public class FiniteStateAnalyzeBinaryRecorder extends BaseFiniteStateRecorder {
     }
 
     @Override
+    protected int executeAnalysis(
+            FilePath cltPath,
+            FilePath filePath,
+            String projectName,
+            String projectVersion,
+            String apiToken,
+            FilePath workspace,
+            Launcher launcher,
+            TaskListener listener)
+            throws IOException, InterruptedException {
+        return executeCLT(
+                cltPath,
+                filePath,
+                projectName,
+                projectVersion,
+                getPreRelease(),
+                apiToken,
+                workspace,
+                launcher,
+                listener);
+    }
+
+    @Override
     protected String getAnalysisType() {
         return "Binary Analysis";
     }
@@ -101,6 +129,88 @@ public class FiniteStateAnalyzeBinaryRecorder extends BaseFiniteStateRecorder {
     @Override
     protected String getFilePathValue() {
         return binaryFilePath;
+    }
+
+    /**
+     * Build the CLT scan-types string from the checkboxes (legacy Alloy transport).
+     */
+    private String buildScanTypesString() {
+        List<String> selectedTypes = new ArrayList<>();
+
+        if (getScaEnabled()) {
+            selectedTypes.add("sca");
+        }
+        if (getSastEnabled()) {
+            selectedTypes.add("sast");
+        }
+        if (getConfigEnabled()) {
+            selectedTypes.add("config");
+        }
+        if (getReachabilityEnabled() && getScaEnabled()) {
+            selectedTypes.add("vulnerability_analysis");
+        }
+
+        // If no scans are selected, default to sca (required)
+        if (selectedTypes.isEmpty()) {
+            selectedTypes.add("sca");
+        }
+
+        return String.join(",", selectedTypes);
+    }
+
+    /**
+     * Execute the CLT command for binary analysis (legacy Alloy transport).
+     */
+    private int executeCLT(
+            FilePath cltPath,
+            FilePath binaryFile,
+            String projectName,
+            String projectVersion,
+            boolean preRelease,
+            String apiToken,
+            FilePath workspace,
+            Launcher launcher,
+            TaskListener listener)
+            throws IOException, InterruptedException {
+
+        // Build the command
+        List<String> command = new ArrayList<>();
+        command.add("java");
+        command.add("-jar");
+        command.add(cltPath.getRemote());
+        command.add("--upload");
+        command.add(binaryFile.getRemote());
+        command.add("--name=" + projectName);
+
+        if (projectVersion != null && !projectVersion.isBlank()) {
+            command.add("--version=" + projectVersion);
+        }
+
+        String computedScanTypes = buildScanTypesString();
+        if (computedScanTypes != null && !computedScanTypes.isBlank()) {
+            command.add("--upload=" + computedScanTypes);
+        }
+
+        if (preRelease) {
+            command.add("--pre-release");
+        }
+
+        listener.getLogger().println("Executing command: " + String.join(" ", command));
+
+        Launcher.ProcStarter starter = launcher.launch();
+        starter.cmds(command);
+        starter.envs(buildCLTEnvironment(apiToken));
+        starter.stdout(listener.getLogger());
+        starter.stderr(listener.getLogger());
+        starter.pwd(workspace);
+
+        int exitCode = starter.join();
+
+        if (exitCode != 0) {
+            listener.getLogger().println("Finite State scan failed with exit code: " + exitCode);
+        }
+
+        return exitCode;
     }
 
     @Symbol("finiteStateAnalyzeBinary")

--- a/src/main/java/io/jenkins/plugins/finitestate/FiniteStateExecutionFramework.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/FiniteStateExecutionFramework.java
@@ -11,10 +11,18 @@ import java.io.IOException;
 /**
  * Execution framework for Finite State analysis operations.
  *
- * <p>Drives the shared flow against the Finite State public v0 API: validate configuration, resolve
- * the API token, compute the target version, locate the workspace file, then run the per-analysis
- * scan flow on the build agent ({@link FiniteStateScanCallable}) and translate the {@link ScanResult}
- * into a Jenkins build outcome. Replaces the previous CLT-jar download-and-exec path.
+ * <p>Dispatches to one of two transports based on {@link BaseFiniteStateRecorder#isHelix()}:
+ *
+ * <ul>
+ *   <li><b>Helix</b> — the public v0 REST API flow ({@link #executeViaApi}): resolve token, compute
+ *       the target version, locate the workspace file, run the scan on the agent
+ *       ({@link FiniteStateScanCallable}) and translate the {@link ScanResult} into a build outcome.
+ *   <li><b>Alloy</b> (default) — the legacy CLT flow ({@link #executeViaClt}): download the CLT jar
+ *       and exec it on the agent, mapping the process exit code onto the build outcome.
+ * </ul>
+ *
+ * <p>Keeping both paths lets a single published plugin serve existing Alloy customers unchanged and
+ * Helix customers by flipping the platform selector. See HELIX-422.
  */
 public class FiniteStateExecutionFramework {
 
@@ -23,16 +31,17 @@ public class FiniteStateExecutionFramework {
     }
 
     /**
-     * Execute a Finite State analysis with common error handling and logging.
+     * Execute a Finite State analysis with common error handling and logging, routing to the Helix
+     * (v0 API) or Alloy (CLT) transport based on the recorder's selected platform.
      *
      * @param recorder Recorder that encapsulates analysis configuration and helpers
      * @param run Jenkins run/build context used for environment and logging
-     * @param workspace Workspace directory where files are accessed
-     * @param launcher Jenkins launcher (unused since the v0 migration; retained for call-site compatibility)
+     * @param workspace Workspace directory where files (and, for Alloy, the CLT) are accessed
+     * @param launcher Jenkins launcher (used by the Alloy transport to exec the CLT)
      * @param listener Build/task listener for console logging
-     * @return true when the scan completed successfully (or was accepted, when not waiting); false on failure
+     * @return true when the analysis succeeded (or was accepted, when not waiting); false on failure
      * @throws InterruptedException if execution is interrupted
-     * @throws IOException if file I/O fails
+     * @throws IOException if file I/O (or CLT download) fails
      */
     public static boolean executeAnalysis(
             BaseFiniteStateRecorder recorder,
@@ -64,6 +73,37 @@ public class FiniteStateExecutionFramework {
                     "N/A");
             return false;
         }
+
+        if (recorder.isHelix()) {
+            listener.getLogger().println("Platform: Helix (public v0 API)");
+            return executeViaApi(recorder, run, workspace, listener, apiToken, analysisType);
+        }
+        listener.getLogger().println("Platform: Alloy (CLT)");
+        return executeViaClt(recorder, run, workspace, launcher, listener, apiToken);
+    }
+
+    /**
+     * Backward-compatible shim for freestyle builds using {@link AbstractBuild} API.
+     */
+    public static boolean executeAnalysis(
+            BaseFiniteStateRecorder recorder, AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException, IOException {
+        FilePath workspace = build.getWorkspace();
+        return executeAnalysis(recorder, (Run<?, ?>) build, workspace, launcher, (TaskListener) listener);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Helix transport (public v0 REST API)
+    // ---------------------------------------------------------------------------------------------
+
+    private static boolean executeViaApi(
+            BaseFiniteStateRecorder recorder,
+            Run<?, ?> run,
+            FilePath workspace,
+            TaskListener listener,
+            String apiToken,
+            String analysisType)
+            throws InterruptedException, IOException {
 
         // Compute the target version (FR-3): externalizable run ID, else projectVersion; fail if both empty.
         String version = recorder.parseVersion(run, recorder.getProjectVersion());
@@ -102,16 +142,6 @@ public class FiniteStateExecutionFramework {
         return handleResult(recorder, run, listener, result);
     }
 
-    /**
-     * Backward-compatible shim for freestyle builds using {@link AbstractBuild} API.
-     */
-    public static boolean executeAnalysis(
-            BaseFiniteStateRecorder recorder, AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
-            throws InterruptedException, IOException {
-        FilePath workspace = build.getWorkspace();
-        return executeAnalysis(recorder, (Run<?, ?>) build, workspace, launcher, (TaskListener) listener);
-    }
-
     private static FiniteStateScanRequest buildRequest(
             BaseFiniteStateRecorder recorder, Run<?, ?> run, String version) {
         FiniteStateScanRequest request = new FiniteStateScanRequest();
@@ -129,7 +159,7 @@ public class FiniteStateExecutionFramework {
     }
 
     /**
-     * Translate the scan result into a build outcome.
+     * Translate the v0 scan result into a build outcome.
      *
      * <p>success → SUCCESS; completed/queued failures (ERROR/timeout) → FAILURE. Build gating is
      * based on terminal scan status only — reading findings back is out of scope for this release.
@@ -165,5 +195,136 @@ public class FiniteStateExecutionFramework {
                 result.getFinalStatus());
         listener.getLogger().println("❌ Finite State " + analysisType + " failed: " + result.getFinalStatus());
         return false;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Alloy transport (legacy CLT jar download-and-exec)
+    // ---------------------------------------------------------------------------------------------
+
+    private static boolean executeViaClt(
+            BaseFiniteStateRecorder recorder,
+            Run<?, ?> run,
+            FilePath workspace,
+            Launcher launcher,
+            TaskListener listener,
+            String parsedApiToken)
+            throws InterruptedException, IOException {
+
+        // Parse version
+        String parsedVersion = recorder.parseVersion(run, recorder.getProjectVersion());
+
+        // Log common information
+        recorder.logCommonInfo(run, listener, recorder.getFilePathValue());
+
+        // Get CLT path
+        FilePath cltPath;
+        try {
+            cltPath = recorder.getCLTPath(workspace, recorder.getSubdomain(), parsedApiToken, listener);
+        } catch (IOException e) {
+            String errorMessage = "ERROR: Failed to download CLT: " + e.getMessage();
+            listener.getLogger().println(errorMessage);
+
+            String consoleOutput = errorMessage + "\nProject: " + recorder.getProjectName() + "\nSubdomain: "
+                    + recorder.getSubdomain() + "\nCredential ID: "
+                    + recorder.getApiTokenCredentialsId();
+            recorder.addConsolidatedResult(
+                    run, recorder.getAnalysisType(), recorder.getProjectName(), consoleOutput, "ERROR", "N/A");
+
+            return false;
+        }
+
+        // Verify file exists
+        FilePath fileObj = recorder.getFileFromWorkspace(workspace, recorder.getFilePathValue(), listener);
+        if (fileObj == null || !fileObj.exists()) {
+            String errorMessage =
+                    "ERROR: " + recorder.getFilePathFieldName() + " not found: " + recorder.getFilePathValue();
+            listener.getLogger().println(errorMessage);
+
+            String consoleOutput = errorMessage + "\nProject: " + recorder.getProjectName() + "\n"
+                    + recorder.getFilePathFieldName() + ": " + recorder.getFilePathValue();
+            recorder.addConsolidatedResult(
+                    run, recorder.getAnalysisType(), recorder.getProjectName(), consoleOutput, "ERROR", "N/A");
+
+            return false;
+        }
+
+        // Execute the analysis
+        listener.getLogger().println("Executing Finite State " + recorder.getAnalysisType() + "...");
+        int exitCode = recorder.executeAnalysis(
+                cltPath,
+                fileObj,
+                recorder.getProjectName(),
+                parsedVersion,
+                parsedApiToken,
+                workspace,
+                launcher,
+                listener);
+
+        return handleExitCode(recorder, run, listener, exitCode, parsedVersion);
+    }
+
+    /**
+     * Handle the exit code from the legacy CLT execution.
+     *
+     * <p>Exit code 0 is treated as success, 1 as a successful run with warnings (vulnerabilities
+     * found), and any other code as error.
+     */
+    private static boolean handleExitCode(
+            BaseFiniteStateRecorder recorder,
+            Run<?, ?> run,
+            TaskListener listener,
+            int exitCode,
+            String parsedVersion) {
+
+        String scanUrl = "https://" + recorder.getSubdomain();
+
+        if (exitCode == 0) {
+            String consoleOutput = buildSuccessMessage(recorder, parsedVersion, exitCode);
+            recorder.addConsolidatedResult(
+                    run, recorder.getAnalysisType(), recorder.getProjectName(), consoleOutput, "SUCCESS", scanUrl);
+
+            listener.getLogger().println("✅ Finite State " + recorder.getAnalysisType() + " started successfully!");
+            return true;
+
+        } else if (exitCode == 1) {
+            String consoleOutput = buildWarningMessage(recorder, parsedVersion, exitCode);
+            recorder.addConsolidatedResult(
+                    run, recorder.getAnalysisType(), recorder.getProjectName(), consoleOutput, "WARNING", scanUrl);
+
+            listener.getLogger()
+                    .println(
+                            "⚠️ Finite State " + recorder.getAnalysisType() + " completed with vulnerabilities found.");
+            return true;
+
+        } else {
+            String consoleOutput = buildErrorMessage(recorder, parsedVersion, exitCode);
+            recorder.addConsolidatedResult(
+                    run, recorder.getAnalysisType(), recorder.getProjectName(), consoleOutput, "ERROR", "N/A");
+
+            listener.getLogger()
+                    .println("❌ Finite State " + recorder.getAnalysisType() + " failed with exit code: " + exitCode);
+            return false;
+        }
+    }
+
+    private static String buildSuccessMessage(BaseFiniteStateRecorder recorder, String parsedVersion, int exitCode) {
+        return "Finite State " + recorder.getAnalysisType() + " started successfully!\n"
+                + recorder.getFilePathFieldName() + ": " + recorder.getFilePathValue() + "\n"
+                + "Project Version: " + parsedVersion + "\n"
+                + "Exit Code: " + exitCode;
+    }
+
+    private static String buildWarningMessage(BaseFiniteStateRecorder recorder, String parsedVersion, int exitCode) {
+        return "Finite State " + recorder.getAnalysisType() + " completed with vulnerabilities found.\n"
+                + recorder.getFilePathFieldName() + ": " + recorder.getFilePathValue() + "\n"
+                + "Project Version: " + parsedVersion + "\n"
+                + "Exit Code: " + exitCode;
+    }
+
+    private static String buildErrorMessage(BaseFiniteStateRecorder recorder, String parsedVersion, int exitCode) {
+        return "Finite State " + recorder.getAnalysisType() + " failed with exit code: " + exitCode + "\n"
+                + recorder.getFilePathFieldName() + ": " + recorder.getFilePathValue() + "\n"
+                + "Project Version: " + parsedVersion + "\n"
+                + "Exit Code: " + exitCode;
     }
 }

--- a/src/main/java/io/jenkins/plugins/finitestate/FiniteStateExecutionFramework.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/FiniteStateExecutionFramework.java
@@ -11,18 +11,18 @@ import java.io.IOException;
 /**
  * Execution framework for Finite State analysis operations.
  *
- * <p>Dispatches to one of two transports based on {@link BaseFiniteStateRecorder#isHelix()}:
+ * <p>Dispatches to one of two transports based on {@link BaseFiniteStateRecorder#isRestApi()}:
  *
  * <ul>
- *   <li><b>Helix</b> — the public v0 REST API flow ({@link #executeViaApi}): resolve token, compute
- *       the target version, locate the workspace file, run the scan on the agent
+ *   <li><b>2026 platform release</b> — the public v0 REST API flow ({@link #executeViaApi}): resolve
+ *       token, compute the target version, locate the workspace file, run the scan on the agent
  *       ({@link FiniteStateScanCallable}) and translate the {@link ScanResult} into a build outcome.
- *   <li><b>Alloy</b> (default) — the legacy CLT flow ({@link #executeViaClt}): download the CLT jar
- *       and exec it on the agent, mapping the process exit code onto the build outcome.
+ *   <li><b>Legacy platform</b> (default) — the Java CLT flow ({@link #executeViaClt}): download the
+ *       CLT jar and exec it on the agent, mapping the process exit code onto the build outcome.
  * </ul>
  *
- * <p>Keeping both paths lets a single published plugin serve existing Alloy customers unchanged and
- * Helix customers by flipping the platform selector. See HELIX-422.
+ * <p>Keeping both paths lets a single published plugin serve existing legacy-platform jobs unchanged
+ * and 2026-platform jobs by flipping the platform selector. See HELIX-422.
  */
 public class FiniteStateExecutionFramework {
 
@@ -31,13 +31,13 @@ public class FiniteStateExecutionFramework {
     }
 
     /**
-     * Execute a Finite State analysis with common error handling and logging, routing to the Helix
-     * (v0 API) or Alloy (CLT) transport based on the recorder's selected platform.
+     * Execute a Finite State analysis with common error handling and logging, routing to the 2026
+     * platform (v0 API) or legacy platform (CLT) transport based on the recorder's selected platform.
      *
      * @param recorder Recorder that encapsulates analysis configuration and helpers
      * @param run Jenkins run/build context used for environment and logging
-     * @param workspace Workspace directory where files (and, for Alloy, the CLT) are accessed
-     * @param launcher Jenkins launcher (used by the Alloy transport to exec the CLT)
+     * @param workspace Workspace directory where files (and, for the legacy platform, the CLT) are accessed
+     * @param launcher Jenkins launcher (used by the legacy CLT transport to exec the CLT)
      * @param listener Build/task listener for console logging
      * @return true when the analysis succeeded (or was accepted, when not waiting); false on failure
      * @throws InterruptedException if execution is interrupted
@@ -74,11 +74,11 @@ public class FiniteStateExecutionFramework {
             return false;
         }
 
-        if (recorder.isHelix()) {
-            listener.getLogger().println("Platform: Helix (public v0 API)");
+        if (recorder.isRestApi()) {
+            listener.getLogger().println("Platform: 2026 Release (REST API)");
             return executeViaApi(recorder, run, workspace, listener, apiToken, analysisType);
         }
-        listener.getLogger().println("Platform: Alloy (CLT)");
+        listener.getLogger().println("Platform: Legacy (Java CLT)");
         return executeViaClt(recorder, run, workspace, launcher, listener, apiToken);
     }
 
@@ -93,7 +93,7 @@ public class FiniteStateExecutionFramework {
     }
 
     // ---------------------------------------------------------------------------------------------
-    // Helix transport (public v0 REST API)
+    // 2026 platform transport (public v0 REST API)
     // ---------------------------------------------------------------------------------------------
 
     private static boolean executeViaApi(
@@ -198,7 +198,7 @@ public class FiniteStateExecutionFramework {
     }
 
     // ---------------------------------------------------------------------------------------------
-    // Alloy transport (legacy CLT jar download-and-exec)
+    // Legacy platform transport (Java CLT jar download-and-exec)
     // ---------------------------------------------------------------------------------------------
 
     private static boolean executeViaClt(

--- a/src/main/java/io/jenkins/plugins/finitestate/FiniteStateSBOMImportRecorder.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/FiniteStateSBOMImportRecorder.java
@@ -86,7 +86,7 @@ public class FiniteStateSBOMImportRecorder extends BaseFiniteStateRecorder {
     }
 
     /**
-     * Execute the SBOM import command (legacy Alloy transport).
+     * Execute the SBOM import command (legacy platform transport).
      */
     private int executeSBOMImport(
             FilePath cltPath,

--- a/src/main/java/io/jenkins/plugins/finitestate/FiniteStateSBOMImportRecorder.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/FiniteStateSBOMImportRecorder.java
@@ -1,8 +1,13 @@
 package io.jenkins.plugins.finitestate;
 
 import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import javax.servlet.ServletException;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -43,6 +48,29 @@ public class FiniteStateSBOMImportRecorder extends BaseFiniteStateRecorder {
     }
 
     @Override
+    protected int executeAnalysis(
+            FilePath cltPath,
+            FilePath filePath,
+            String projectName,
+            String projectVersion,
+            String apiToken,
+            FilePath workspace,
+            Launcher launcher,
+            TaskListener listener)
+            throws IOException, InterruptedException {
+        return executeSBOMImport(
+                cltPath,
+                filePath,
+                projectName,
+                projectVersion,
+                getPreRelease(),
+                apiToken,
+                workspace,
+                launcher,
+                listener);
+    }
+
+    @Override
     protected String getAnalysisType() {
         return "SBOM Import";
     }
@@ -55,6 +83,46 @@ public class FiniteStateSBOMImportRecorder extends BaseFiniteStateRecorder {
     @Override
     protected String getFilePathValue() {
         return sbomFilePath;
+    }
+
+    /**
+     * Execute the SBOM import command (legacy Alloy transport).
+     */
+    private int executeSBOMImport(
+            FilePath cltPath,
+            FilePath sbomFile,
+            String projectName,
+            String projectVersion,
+            boolean preRelease,
+            String apiToken,
+            FilePath workspace,
+            Launcher launcher,
+            TaskListener listener)
+            throws IOException, InterruptedException {
+
+        List<String> command = new ArrayList<>();
+        command.add("java");
+        command.add("-jar");
+        command.add(cltPath.getRemote());
+        command.add("--import");
+        command.add("--name=" + projectName);
+        command.add("--version=" + projectVersion);
+        command.add(sbomFile.getRemote());
+
+        if (preRelease) {
+            command.add("--pre-release");
+        }
+
+        listener.getLogger().println("Executing command: " + String.join(" ", command));
+
+        Launcher.ProcStarter starter = launcher.launch();
+        starter.cmds(command);
+        starter.envs(buildCLTEnvironment(apiToken));
+        starter.stdout(listener.getLogger());
+        starter.stderr(listener.getLogger());
+        starter.pwd(workspace);
+
+        return starter.join();
     }
 
     @Symbol("finiteStateImportSbom")

--- a/src/main/java/io/jenkins/plugins/finitestate/FiniteStateThirdPartyImportRecorder.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/FiniteStateThirdPartyImportRecorder.java
@@ -97,7 +97,7 @@ public class FiniteStateThirdPartyImportRecorder extends BaseFiniteStateRecorder
     }
 
     /**
-     * Execute the third party import command (legacy Alloy transport).
+     * Execute the third party import command (legacy platform transport).
      */
     private int executeThirdPartyImport(
             FilePath cltPath,

--- a/src/main/java/io/jenkins/plugins/finitestate/FiniteStateThirdPartyImportRecorder.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/FiniteStateThirdPartyImportRecorder.java
@@ -1,9 +1,14 @@
 package io.jenkins.plugins.finitestate;
 
 import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import javax.servlet.ServletException;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -53,6 +58,30 @@ public class FiniteStateThirdPartyImportRecorder extends BaseFiniteStateRecorder
     }
 
     @Override
+    protected int executeAnalysis(
+            FilePath cltPath,
+            FilePath filePath,
+            String projectName,
+            String projectVersion,
+            String apiToken,
+            FilePath workspace,
+            Launcher launcher,
+            TaskListener listener)
+            throws IOException, InterruptedException {
+        return executeThirdPartyImport(
+                cltPath,
+                filePath,
+                projectName,
+                projectVersion,
+                scanType,
+                getPreRelease(),
+                apiToken,
+                workspace,
+                launcher,
+                listener);
+    }
+
+    @Override
     protected String getAnalysisType() {
         return "Third Party Import";
     }
@@ -65,6 +94,47 @@ public class FiniteStateThirdPartyImportRecorder extends BaseFiniteStateRecorder
     @Override
     protected String getFilePathValue() {
         return scanFilePath;
+    }
+
+    /**
+     * Execute the third party import command (legacy Alloy transport).
+     */
+    private int executeThirdPartyImport(
+            FilePath cltPath,
+            FilePath scanFile,
+            String projectName,
+            String projectVersion,
+            String scanType,
+            boolean preRelease,
+            String apiToken,
+            FilePath workspace,
+            Launcher launcher,
+            TaskListener listener)
+            throws IOException, InterruptedException {
+
+        List<String> command = new ArrayList<>();
+        command.add("java");
+        command.add("-jar");
+        command.add(cltPath.getRemote());
+        command.add("--thirdParty=" + scanType);
+        command.add("--name=" + projectName);
+        command.add("--version=" + projectVersion);
+        command.add(scanFile.getRemote());
+
+        if (preRelease) {
+            command.add("--pre-release");
+        }
+
+        listener.getLogger().println("Executing command: " + String.join(" ", command));
+
+        Launcher.ProcStarter starter = launcher.launch();
+        starter.cmds(command);
+        starter.envs(buildCLTEnvironment(apiToken));
+        starter.stdout(listener.getLogger());
+        starter.stderr(listener.getLogger());
+        starter.pwd(workspace);
+
+        return starter.join();
     }
 
     @Symbol("finiteStateImportThirdParty")

--- a/src/main/resources/io/jenkins/plugins/finitestate/BaseFiniteStateRecorder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/finitestate/BaseFiniteStateRecorder/config.jelly
@@ -2,6 +2,10 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:c="/lib/credentials" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <st:adjunct includes="io/jenkins/plugins/finitestate/common/js/dynamic_events"/>
     <div class="finite-state-common">
+      <f:entry title="Platform" field="platform" description="Select the Finite State platform this job targets. Alloy (default) uses the legacy CLT; Helix uses the public v0 API. Leave as Alloy unless your organization has migrated to Helix.">
+        <f:select default="alloy" />
+      </f:entry>
+
       <f:entry title="Subdomain" field="subdomain">
         <f:textbox />
       </f:entry>

--- a/src/main/resources/io/jenkins/plugins/finitestate/BaseFiniteStateRecorder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/finitestate/BaseFiniteStateRecorder/config.jelly
@@ -2,8 +2,8 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:c="/lib/credentials" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <st:adjunct includes="io/jenkins/plugins/finitestate/common/js/dynamic_events"/>
     <div class="finite-state-common">
-      <f:entry title="Platform" field="platform" description="Select the Finite State platform this job targets. Alloy (default) uses the legacy CLT; Helix uses the public v0 API. Leave as Alloy unless your organization has migrated to Helix.">
-        <f:select default="alloy" />
+      <f:entry title="Platform" field="platform" description="Select the Finite State platform this job targets. Legacy Platform (default) uses the Java CLT; the 2026 Platform Release uses the public v0 REST API. Leave as Legacy Platform unless your organization has been upgraded to the 2026 platform release.">
+        <f:select default="legacy" />
       </f:entry>
 
       <f:entry title="Subdomain" field="subdomain">

--- a/src/main/resources/io/jenkins/plugins/finitestate/BaseFiniteStateRecorder/help-platform.html
+++ b/src/main/resources/io/jenkins/plugins/finitestate/BaseFiniteStateRecorder/help-platform.html
@@ -1,0 +1,13 @@
+<div>
+  Selects which Finite State platform (and transport) this build step targets:
+  <ul>
+    <li><b>Alloy (legacy CLT)</b> &mdash; the default. Downloads and runs the Finite State
+      command-line tool (CLT) on the build agent, exactly as previous plugin versions did. Requires
+      Java on the agent. Choose this if your organization is still on the Alloy platform.</li>
+    <li><b>Helix (public v0 API)</b> &mdash; calls the Finite State public v0 REST API directly.
+      No CLT download and no Java required on the agent. Choose this only if your organization has
+      been migrated to the Helix platform.</li>
+  </ul>
+  Jobs saved before this option existed default to <b>Alloy</b>, so upgrading the plugin does not
+  change their behavior.
+</div>

--- a/src/main/resources/io/jenkins/plugins/finitestate/BaseFiniteStateRecorder/help-platform.html
+++ b/src/main/resources/io/jenkins/plugins/finitestate/BaseFiniteStateRecorder/help-platform.html
@@ -1,13 +1,13 @@
 <div>
   Selects which Finite State platform (and transport) this build step targets:
   <ul>
-    <li><b>Alloy (legacy CLT)</b> &mdash; the default. Downloads and runs the Finite State
-      command-line tool (CLT) on the build agent, exactly as previous plugin versions did. Requires
-      Java on the agent. Choose this if your organization is still on the Alloy platform.</li>
-    <li><b>Helix (public v0 API)</b> &mdash; calls the Finite State public v0 REST API directly.
-      No CLT download and no Java required on the agent. Choose this only if your organization has
-      been migrated to the Helix platform.</li>
+    <li><b>Legacy Platform (Java CLT)</b> &mdash; the default. Downloads and runs the Finite State
+      Java command-line tool (CLT) on the build agent, exactly as previous plugin versions did.
+      Requires Java on the agent. Choose this if your organization is still on the legacy platform.</li>
+    <li><b>2026 Platform Release (REST API)</b> &mdash; calls the Finite State public v0 REST API
+      directly. No CLT download and no Java required on the agent. Choose this only once your
+      organization has been upgraded to the 2026 platform release.</li>
   </ul>
-  Jobs saved before this option existed default to <b>Alloy</b>, so upgrading the plugin does not
-  change their behavior.
+  Jobs saved before this option existed default to <b>Legacy Platform</b>, so upgrading the plugin
+  does not change their behavior.
 </div>

--- a/src/test/java/io/jenkins/plugins/finitestate/BaseFiniteStateRecorderPlatformTest.java
+++ b/src/test/java/io/jenkins/plugins/finitestate/BaseFiniteStateRecorderPlatformTest.java
@@ -1,0 +1,57 @@
+package io.jenkins.plugins.finitestate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Guards the HELIX-422 backward-compatibility contract: a recorder defaults to the legacy Alloy
+ * (CLT) transport, so a job saved before the {@code platform} field existed (its persisted XML has
+ * no {@code platform}) keeps running against Alloy after the plugin is upgraded. Helix is opt-in.
+ */
+public class BaseFiniteStateRecorderPlatformTest {
+
+    private BaseFiniteStateRecorder newRecorder() {
+        // Any concrete recorder exercises the shared base behavior.
+        return new FiniteStateAnalyzeBinaryRecorder("test", "token", "path", "project");
+    }
+
+    @Test
+    public void defaultsToAlloyWhenUnset() {
+        BaseFiniteStateRecorder recorder = newRecorder();
+        assertEquals(BaseFiniteStateRecorder.PLATFORM_ALLOY, recorder.getPlatform());
+        assertFalse("unset platform must not route to Helix", recorder.isHelix());
+    }
+
+    @Test
+    public void blankPlatformFallsBackToAlloy() {
+        BaseFiniteStateRecorder recorder = newRecorder();
+        recorder.setPlatform("   ");
+        assertEquals(BaseFiniteStateRecorder.PLATFORM_ALLOY, recorder.getPlatform());
+        assertFalse(recorder.isHelix());
+    }
+
+    @Test
+    public void helixIsOptIn() {
+        BaseFiniteStateRecorder recorder = newRecorder();
+        recorder.setPlatform(BaseFiniteStateRecorder.PLATFORM_HELIX);
+        assertTrue(recorder.isHelix());
+        assertEquals(BaseFiniteStateRecorder.PLATFORM_HELIX, recorder.getPlatform());
+    }
+
+    @Test
+    public void explicitAlloyStaysAlloy() {
+        BaseFiniteStateRecorder recorder = newRecorder();
+        recorder.setPlatform(BaseFiniteStateRecorder.PLATFORM_ALLOY);
+        assertFalse(recorder.isHelix());
+    }
+
+    @Test
+    public void platformMatchIsCaseInsensitive() {
+        BaseFiniteStateRecorder recorder = newRecorder();
+        recorder.setPlatform("HELIX");
+        assertTrue(recorder.isHelix());
+    }
+}

--- a/src/test/java/io/jenkins/plugins/finitestate/BaseFiniteStateRecorderPlatformTest.java
+++ b/src/test/java/io/jenkins/plugins/finitestate/BaseFiniteStateRecorderPlatformTest.java
@@ -7,9 +7,10 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
- * Guards the HELIX-422 backward-compatibility contract: a recorder defaults to the legacy Alloy
- * (CLT) transport, so a job saved before the {@code platform} field existed (its persisted XML has
- * no {@code platform}) keeps running against Alloy after the plugin is upgraded. Helix is opt-in.
+ * Guards the HELIX-422 backward-compatibility contract: a recorder defaults to the legacy platform
+ * (Java CLT), so a job saved before the {@code platform} field existed (its persisted XML has no
+ * {@code platform}) keeps running against the legacy platform after the plugin is upgraded. The
+ * 2026 platform release (REST API) is opt-in.
  */
 public class BaseFiniteStateRecorderPlatformTest {
 
@@ -19,39 +20,40 @@ public class BaseFiniteStateRecorderPlatformTest {
     }
 
     @Test
-    public void defaultsToAlloyWhenUnset() {
+    public void defaultsToLegacyWhenUnset() {
         BaseFiniteStateRecorder recorder = newRecorder();
-        assertEquals(BaseFiniteStateRecorder.PLATFORM_ALLOY, recorder.getPlatform());
-        assertFalse("unset platform must not route to Helix", recorder.isHelix());
+        assertEquals(BaseFiniteStateRecorder.PLATFORM_LEGACY, recorder.getPlatform());
+        assertFalse("unset platform must not route to the REST API", recorder.isRestApi());
     }
 
     @Test
-    public void blankPlatformFallsBackToAlloy() {
+    public void blankPlatformFallsBackToLegacy() {
         BaseFiniteStateRecorder recorder = newRecorder();
         recorder.setPlatform("   ");
-        assertEquals(BaseFiniteStateRecorder.PLATFORM_ALLOY, recorder.getPlatform());
-        assertFalse(recorder.isHelix());
+        assertEquals(BaseFiniteStateRecorder.PLATFORM_LEGACY, recorder.getPlatform());
+        assertFalse(recorder.isRestApi());
     }
 
     @Test
-    public void helixIsOptIn() {
+    public void restApiIsOptIn() {
         BaseFiniteStateRecorder recorder = newRecorder();
-        recorder.setPlatform(BaseFiniteStateRecorder.PLATFORM_HELIX);
-        assertTrue(recorder.isHelix());
-        assertEquals(BaseFiniteStateRecorder.PLATFORM_HELIX, recorder.getPlatform());
+        recorder.setPlatform(BaseFiniteStateRecorder.PLATFORM_2026);
+        assertTrue(recorder.isRestApi());
+        assertEquals(BaseFiniteStateRecorder.PLATFORM_2026, recorder.getPlatform());
     }
 
     @Test
-    public void explicitAlloyStaysAlloy() {
+    public void explicitLegacyStaysLegacy() {
         BaseFiniteStateRecorder recorder = newRecorder();
-        recorder.setPlatform(BaseFiniteStateRecorder.PLATFORM_ALLOY);
-        assertFalse(recorder.isHelix());
+        recorder.setPlatform(BaseFiniteStateRecorder.PLATFORM_LEGACY);
+        assertFalse(recorder.isRestApi());
     }
 
     @Test
-    public void platformMatchIsCaseInsensitive() {
+    public void unknownPlatformIsNotRestApi() {
+        // Any value other than the 2026 release resolves to the safe legacy (CLT) path.
         BaseFiniteStateRecorder recorder = newRecorder();
-        recorder.setPlatform("HELIX");
-        assertTrue(recorder.isHelix());
+        recorder.setPlatform("some-future-value");
+        assertFalse(recorder.isRestApi());
     }
 }

--- a/src/test/java/io/jenkins/plugins/finitestate/FiniteStatePlatformRoutingTest.java
+++ b/src/test/java/io/jenkins/plugins/finitestate/FiniteStatePlatformRoutingTest.java
@@ -1,0 +1,98 @@
+package io.jenkins.plugins.finitestate;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleProject;
+import hudson.util.Secret;
+import java.io.IOException;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+
+/**
+ * Runs the plugin inside a real Jenkins ({@link JenkinsRule}) and drives a build under each
+ * {@code platform} to prove the HELIX-422 transport switch end-to-end: data-binding → perform() →
+ * {@link FiniteStateExecutionFramework} dispatch → the correct network boundary.
+ *
+ * <p>The subdomain points at a reserved {@code .invalid} host (RFC 2606), so both transports fail
+ * fast at connect. We assert on which transport was <em>selected and attempted</em> — the Alloy run
+ * must reach the CLT download endpoint ({@code /api/config/clt}) and the Helix run must go through
+ * the v0 API path — not on scan success (which would require a live backend).
+ */
+public class FiniteStatePlatformRoutingTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private static final String UNREACHABLE_SUBDOMAIN = "fs-routing-test.invalid";
+
+    private String addTokenCredential() throws Exception {
+        StringCredentialsImpl cred = new StringCredentialsImpl(
+                CredentialsScope.GLOBAL, "fs-token", "routing test", Secret.fromString("secret-token"));
+        SystemCredentialsProvider.getInstance().getCredentials().add(cred);
+        SystemCredentialsProvider.getInstance().save();
+        return "fs-token";
+    }
+
+    /** Writes the artifact the recorder expects, so we reach the transport instead of a file error. */
+    private static final class WriteScanFile extends TestBuilder {
+        @Override
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+                throws InterruptedException, IOException {
+            build.getWorkspace().child("scan.bin").write("payload", "UTF-8");
+            return true;
+        }
+    }
+
+    private FiniteStateAnalyzeBinaryRecorder recorder(String platform) throws Exception {
+        FiniteStateAnalyzeBinaryRecorder r =
+                new FiniteStateAnalyzeBinaryRecorder(UNREACHABLE_SUBDOMAIN, addTokenCredential(), "scan.bin", "proj");
+        r.setProjectVersion("1.0");
+        r.setPlatform(platform);
+        return r;
+    }
+
+    private String runAndGetLog(String platform) throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new WriteScanFile());
+        p.getPublishersList().add(recorder(platform));
+        return j.getLog(p.scheduleBuild2(0).get());
+    }
+
+    @Test
+    public void alloyPlatformUsesCltTransport() throws Exception {
+        String log = runAndGetLog(BaseFiniteStateRecorder.PLATFORM_ALLOY);
+        assertTrue("should announce the Alloy transport:\n" + log, log.contains("Platform: Alloy (CLT)"));
+        assertTrue("should attempt the CLT download endpoint:\n" + log, log.contains("/api/config/clt"));
+        assertFalse("must not touch the Helix API path:\n" + log, log.contains("via the Finite State API"));
+    }
+
+    @Test
+    public void helixPlatformUsesV0Transport() throws Exception {
+        String log = runAndGetLog(BaseFiniteStateRecorder.PLATFORM_HELIX);
+        assertTrue("should announce the Helix transport:\n" + log, log.contains("Platform: Helix (public v0 API)"));
+        assertTrue("should go through the v0 API path:\n" + log, log.contains("via the Finite State API"));
+        assertFalse("must not download the CLT:\n" + log, log.contains("/api/config/clt"));
+    }
+
+    @Test
+    public void defaultPlatformIsAlloy() throws Exception {
+        // No setPlatform() call — mirrors a job whose persisted config predates the field.
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.getBuildersList().add(new WriteScanFile());
+        FiniteStateAnalyzeBinaryRecorder r =
+                new FiniteStateAnalyzeBinaryRecorder(UNREACHABLE_SUBDOMAIN, addTokenCredential(), "scan.bin", "proj");
+        r.setProjectVersion("1.0");
+        p.getPublishersList().add(r);
+        String log = j.getLog(p.scheduleBuild2(0).get());
+        assertTrue("unset platform must default to Alloy:\n" + log, log.contains("Platform: Alloy (CLT)"));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/finitestate/FiniteStatePlatformRoutingTest.java
+++ b/src/test/java/io/jenkins/plugins/finitestate/FiniteStatePlatformRoutingTest.java
@@ -23,9 +23,9 @@ import org.jvnet.hudson.test.TestBuilder;
  * {@link FiniteStateExecutionFramework} dispatch → the correct network boundary.
  *
  * <p>The subdomain points at a reserved {@code .invalid} host (RFC 2606), so both transports fail
- * fast at connect. We assert on which transport was <em>selected and attempted</em> — the Alloy run
- * must reach the CLT download endpoint ({@code /api/config/clt}) and the Helix run must go through
- * the v0 API path — not on scan success (which would require a live backend).
+ * fast at connect. We assert on which transport was <em>selected and attempted</em> — the legacy run
+ * must reach the CLT download endpoint ({@code /api/config/clt}) and the 2026-release run must go
+ * through the v0 API path — not on scan success (which would require a live backend).
  */
 public class FiniteStatePlatformRoutingTest {
 
@@ -68,23 +68,25 @@ public class FiniteStatePlatformRoutingTest {
     }
 
     @Test
-    public void alloyPlatformUsesCltTransport() throws Exception {
-        String log = runAndGetLog(BaseFiniteStateRecorder.PLATFORM_ALLOY);
-        assertTrue("should announce the Alloy transport:\n" + log, log.contains("Platform: Alloy (CLT)"));
+    public void legacyPlatformUsesCltTransport() throws Exception {
+        String log = runAndGetLog(BaseFiniteStateRecorder.PLATFORM_LEGACY);
+        assertTrue("should announce the legacy transport:\n" + log, log.contains("Platform: Legacy (Java CLT)"));
         assertTrue("should attempt the CLT download endpoint:\n" + log, log.contains("/api/config/clt"));
-        assertFalse("must not touch the Helix API path:\n" + log, log.contains("via the Finite State API"));
+        assertFalse("must not touch the REST API path:\n" + log, log.contains("via the Finite State API"));
     }
 
     @Test
-    public void helixPlatformUsesV0Transport() throws Exception {
-        String log = runAndGetLog(BaseFiniteStateRecorder.PLATFORM_HELIX);
-        assertTrue("should announce the Helix transport:\n" + log, log.contains("Platform: Helix (public v0 API)"));
+    public void restApiPlatformUsesV0Transport() throws Exception {
+        String log = runAndGetLog(BaseFiniteStateRecorder.PLATFORM_2026);
+        assertTrue(
+                "should announce the 2026 release transport:\n" + log,
+                log.contains("Platform: 2026 Release (REST API)"));
         assertTrue("should go through the v0 API path:\n" + log, log.contains("via the Finite State API"));
         assertFalse("must not download the CLT:\n" + log, log.contains("/api/config/clt"));
     }
 
     @Test
-    public void defaultPlatformIsAlloy() throws Exception {
+    public void defaultPlatformIsLegacy() throws Exception {
         // No setPlatform() call — mirrors a job whose persisted config predates the field.
         FreeStyleProject p = j.createFreeStyleProject();
         p.getBuildersList().add(new WriteScanFile());
@@ -93,6 +95,6 @@ public class FiniteStatePlatformRoutingTest {
         r.setProjectVersion("1.0");
         p.getPublishersList().add(r);
         String log = j.getLog(p.scheduleBuild2(0).get());
-        assertTrue("unset platform must default to Alloy:\n" + log, log.contains("Platform: Alloy (CLT)"));
+        assertTrue("unset platform must default to Legacy:\n" + log, log.contains("Platform: Legacy (Java CLT)"));
     }
 }


### PR DESCRIPTION
## Why (HELIX-422)

The v0 migration (#26) replaced the Java CLT transport with the public v0 REST API **and deleted the CLT path entirely**. Publishing that to the Jenkins Update Center would break **every current customer**: all known Jenkins users are still on the legacy platform, and unlike the Azure DevOps extension (which ships `@1`/`@2` task majors side by side), the Jenkins Update Center serves **only the latest version per plugin ID** — there is no dual-version channel and no per-customer targeting. Any legacy-platform customer who updates (or fresh-installs) would silently retarget the REST API and fail.

This PR makes a **single published plugin safe for both audiences**, which is the backward-compatibility pattern Jenkins' own docs recommend for breaking changes.

## What

Keep both transports in one plugin and choose per build step via a new **`platform`** field:

| `platform` value | Dropdown label | Transport |
|---|---|---|
| `legacy` (**default**) | Legacy Platform (Java CLT) | Downloads + runs the Java CLT jar (requires Java on the agent). Identical to plugin ≤ `1.092`. |
| `2026` | 2026 Platform Release (REST API) | Calls the public v0 REST API directly. No CLT, no Java on the agent. Opt-in. |

**Backward-compat contract:** a job whose persisted config predates this field has no `<platform>` element → deserializes to `null` → `getPlatform()` returns `legacy`. **Upgrading the plugin never changes an existing job's behavior.** The 2026 REST API path is strictly opt-in — a customer selects it once their org has been *upgraded* to the 2026 platform release.

### Changes
- `BaseFiniteStateRecorder`: `platform` field + `getPlatform()`/`isRestApi()`; restored `getCLTPath()` + `buildCLTEnvironment()` + abstract CLT `executeAnalysis(...)`, kept alongside the v0 `configureRequest(...)`.
- `FiniteStateExecutionFramework`: dispatches on `isRestApi()` → `executeViaApi` (v0) or `executeViaClt` (CLT); console logs `Platform: Legacy (Java CLT)` / `Platform: 2026 Release (REST API)`.
- 3 recorders: each keeps `configureRequest` (v0) and regains its CLT `executeAnalysis`.
- `CLTManager` restored (from `793c6eb`, the published `1.092` state).
- UI: **Platform** dropdown (Legacy listed first / default) + help + `doFillPlatformItems()`.
- Docs: README + pipeline usage (`platform: '2026'`).
- Tests: `BaseFiniteStateRecorderPlatformTest` (default-legacy / opt-in) + `FiniteStatePlatformRoutingTest` (real `JenkinsRule`, asserts the transport taken per platform).

## Verification
- `mvn verify` green: **21 tests**, Spotless clean, SpotBugs clean, `.hpi` builds.
- **Full e2e against live backends** (real Jenkins via `mvn hpi:run`): 4 jobs (freestyle + pipeline × legacy + 2026), each running all 3 tasks (binary / SBOM / third-party) = **12 task runs, all SUCCESS**. Legacy → CLT upload; 2026 → v0 REST API. Backend-confirmed with real component/finding data on both platforms. Details + console evidence in the comments below (note: earlier comments predate the terminology rename and show the old `Platform: …` strings).
- Built with Maven 3.9.9 (parent `5.19` requires ≥ 3.9.6).

## Terminology
Internal codenames are intentionally kept out of every user-facing surface. The two options are **Legacy Platform (Java CLT)** and **2026 Platform Release (REST API)**; prose says a job runs on the new platform once an org is **upgraded**. `isRestApi()` names the behavioral branch (REST API vs CLT) rather than a release codename.

> Note: SBOM/third-party on the 2026 platform depend on HELIX-399 being resolved for e2e — confirmed working in the live run above. The legacy CLT path is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)