### PR TITLE
fix(security): store the API token as hudson.util.Secret

### DIFF
--- a/src/main/java/io/jenkins/plugins/finitestate/FiniteStateApiClient.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/FiniteStateApiClient.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.finitestate;
 
 import hudson.model.TaskListener;
+import hudson.util.Secret;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -49,12 +50,12 @@ final class FiniteStateApiClient {
     private static final Set<String> FAILURE_TERMINAL = Set.of("ERROR", "CANCELLED", "UPLOAD_FAILED");
 
     private final String baseUrl;
-    private final String apiToken;
+    private final Secret apiToken;
     private final String subdomain;
     private final TaskListener listener;
     private final HttpClient http;
 
-    FiniteStateApiClient(String subdomain, String apiToken, TaskListener listener) {
+    FiniteStateApiClient(String subdomain, Secret apiToken, TaskListener listener) {
         this.subdomain = subdomain;
         this.baseUrl = "https://" + subdomain + "/api/public/v0";
         this.apiToken = apiToken;
@@ -453,7 +454,7 @@ final class FiniteStateApiClient {
 
     private HttpRequest.Builder apiReq(String path) {
         return HttpRequest.newBuilder(URI.create(baseUrl + path))
-                .header("X-Authorization", apiToken)
+                .header("X-Authorization", apiToken.getPlainText())
                 .header("Accept", "application/json")
                 .header("User-Agent", USER_AGENT)
                 .timeout(Duration.ofMinutes(2));

--- a/src/main/java/io/jenkins/plugins/finitestate/FiniteStateScanRequest.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/FiniteStateScanRequest.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.finitestate;
 
+import hudson.util.Secret;
 import java.io.Serializable;
 
 /**
@@ -20,7 +21,9 @@ public class FiniteStateScanRequest implements Serializable {
 
     // --- Common ---
     private String subdomain;
-    private String apiToken;
+    // Stored as Secret so the serialized form (shipped to the agent over remoting) is encrypted,
+    // never plaintext — see Jenkins Security Scan "Plaintext password storage".
+    private Secret apiToken;
     private String projectName;
     private String version;
     private boolean preRelease;
@@ -47,12 +50,12 @@ public class FiniteStateScanRequest implements Serializable {
         this.subdomain = subdomain;
     }
 
-    public String getApiToken() {
+    public Secret getApiToken() {
         return apiToken;
     }
 
     public void setApiToken(String apiToken) {
-        this.apiToken = apiToken;
+        this.apiToken = apiToken == null ? null : Secret.fromString(apiToken);
     }
 
     public String getProjectName() {


### PR DESCRIPTION
## Why
The Jenkins Security Scan (CodeQL rule *"Plaintext password storage"*) flagged the `apiToken` String fields in `FiniteStateScanRequest` and `FiniteStateApiClient` (see the annotations on the jenkinsci sync PR #7).

Neither was an actual secret-at-rest exposure — job configuration persists only the credential ID (`apiTokenCredentialsId`), never the token. But `FiniteStateScanRequest` **is** `Serializable` and carries the token to the build agent over remoting, where a plaintext `String` field is avoidable. This change addresses the finding properly rather than dismissing it.

## What
- `FiniteStateScanRequest.apiToken`: `String` → `hudson.util.Secret` (getter returns `Secret`, setter wraps via `Secret.fromString`). The serialized form shipped over remoting is now encrypted.
- `FiniteStateApiClient`: constructor param + field `String` → `Secret`; plaintext is extracted only at the last moment (`getPlainText()`) for the `X-Authorization` header.
- No behavior change; no config-compatibility impact (the token was never in persisted config).

## Verified Secret works over remoting
Confirmed with a throwaway probe (removed before commit) that `Secret.getPlainText()` returns the correct value on a **real separate-JVM agent** (`createOnlineSlave()`), so this is safe for distributed builds — not just the built-in node.

- `mvn verify` green: 21 tests (unit + `JenkinsRule` integration), Spotless clean, SpotBugs clean, HPI builds.

Follow-up to #27 (HELIX-422). Merge this before re-syncing to `jenkinsci` so the release carries the fix and the security-scan alerts clear at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)