### PR TITLE
fix: cap version-scan list at limit=100 (Alloy rejects >100) [HELIX-422]

### DIFF
--- a/src/main/java/io/jenkins/plugins/finitestate/FiniteStateApiClient.java
+++ b/src/main/java/io/jenkins/plugins/finitestate/FiniteStateApiClient.java
@@ -446,9 +446,11 @@ final class FiniteStateApiClient {
     private List<String> resolveScanIdsForVersion(String versionId) throws InterruptedException {
         try {
             // A version holds only a handful of scans (one binary spawns a few, plus SBOM/third-party),
-            // so a single 200-row page always covers it — no pagination needed for per-version scoping.
+            // so a single 100-row page always covers it — no pagination needed for per-version scoping.
+            // limit is capped at 100: the previous backend (Alloy) rejects limit>100 with sqlstate 400
+            // ("maximum: 100"), which would break scan-id resolution + status polling on that backend.
             HttpResponse<String> resp = execGet(
-                    apiReq("/scans?filter=" + enc("projectVersion==\"" + versionId + "\"") + "&limit=200")
+                    apiReq("/scans?filter=" + enc("projectVersion==\"" + versionId + "\"") + "&limit=100")
                             .GET()
                             .build(),
                     "List version scans");
@@ -607,7 +609,7 @@ final class FiniteStateApiClient {
         java.util.Map<String, String> map = new java.util.HashMap<>();
         try {
             HttpResponse<String> resp = execGet(
-                    apiReq("/scans?filter=" + enc("projectVersion==\"" + versionId + "\"") + "&limit=200")
+                    apiReq("/scans?filter=" + enc("projectVersion==\"" + versionId + "\"") + "&limit=100")
                             .GET()
                             .build(),
                     "List version scan statuses");


### PR DESCRIPTION
## What
The version-scan list (`resolveScanIdsForVersion` + `getVersionScanStatuses`) queried `/scans?filter=projectVersion==...&limit=200`. The **previous backend (Alloy) rejects `limit>100`** with HTTP 400 (`"Numeric instance is greater than the required maximum (maximum: 100, found: 200)"`).

## Impact
On Alloy this broke scan-id resolution **and** status polling, so `waitForCompletion: true` could never read terminal status and the build timed out (or degraded with repeated warnings). Helix accepts 200, so it was silent there.

## Fix
Cap the list at `limit=100`. A project version only ever holds a handful of scans (one binary spawns a few, plus SBOM/third-party), so 100 is more than enough — and it's accepted by **both** backends.

## Verification
Found + fixed while running the full `mvn hpi:run` e2e against both live backends. After the fix:
- **Alloy** (`fs-yolo`): all 3 tasks green, binary polled to **COMPLETED**.
- **Helix** (`finite-state-ui-dev`): all 3 tasks submitted via the façade.
Unit suite green (`mvn test`).

Follow-up to #29 (that PR merged just before this commit landed).